### PR TITLE
Dynamically load dependencies on NET 472

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -62,7 +62,7 @@ stages:
         Write-Verbose -Verbose "Importing build utilities (buildtools.psd1)"
         Import-Module -Name $(Build.SourcesDirectory)/buildtools.psd1 -Force
         #
-        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'netstandard2.0'
+        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'net472'
       displayName: Build Module
 
     - pwsh: |
@@ -115,7 +115,7 @@ stages:
       jobName: TestPkgWin
       displayName: PowerShell Core on Windows
       imageName: windows-latest
-  
+
   - template: test.yml
     parameters:
       jobName: TestPkgWinPS

--- a/.ci/ci_auto.yml
+++ b/.ci/ci_auto.yml
@@ -68,8 +68,8 @@ stages:
         Write-Verbose -Verbose "Importing build utilities (buildtools.psd1)"
         Import-Module -Name $(Build.SourcesDirectory)/buildtools.psd1 -Force
         #
-        # Build for netstandard2.0 framework
-        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'netstandard2.0'
+        # Build for net472 framework
+        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'net472'
       displayName: Build module
 
     - pwsh: |
@@ -103,7 +103,7 @@ stages:
         if (! (Test-Path -Path $thirdPartySignSrcPath)) {
           $null = New-Item -Path $thirdPartySignSrcPath -ItemType Directory -Verbose
         }
-        
+
         # NetStandard directory
         $netStandardPath = Join-Path -Path $thirdPartySignSrcPath -ChildPath "netstandard2.0"
         if (! (Test-Path -Path $netStandardPath)) {
@@ -323,7 +323,7 @@ stages:
       jobName: TestPkgWin
       displayName: PowerShell Core on Windows
       imageName: windows-latest
-  
+
   - template: test.yml
     parameters:
       jobName: TestPkgWinPS

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -57,8 +57,8 @@ stages:
         Write-Verbose -Verbose "Importing build utilities (buildtools.psd1)"
         Import-Module -Name $(Build.SourcesDirectory)/buildtools.psd1 -Force
         #
-        # Build for netstandard2.0 framework
-        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'netstandard2.0'
+        # Build for net472 framework
+        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'net472'
       displayName: Build and publish artifact
 
     - pwsh: |
@@ -92,7 +92,7 @@ stages:
         if (! (Test-Path -Path $thirdPartySignSrcPath)) {
           $null = New-Item -Path $thirdPartySignSrcPath -ItemType Directory -Verbose
         }
-        
+
         # NetStandard directory
         $netStandardPath = Join-Path -Path $thirdPartySignSrcPath -ChildPath "netstandard2.0"
         if (! (Test-Path -Path $netStandardPath)) {
@@ -128,7 +128,7 @@ stages:
         $config = Get-BuildConfiguration
 
         $thirdPartySignSrcPath = "$($config.BuildOutputPath)\ThirdParty"
-        Get-ChildItem -Path $thirdPartySignSrcPath -Recurse 
+        Get-ChildItem -Path $thirdPartySignSrcPath -Recurse
       displayName: Capture third party files for signing
       condition: succeededOrFailed()
 
@@ -149,7 +149,7 @@ stages:
         $config = Get-BuildConfiguration
 
         $signOutPath = "$($config.SignedOutputPath)\$($config.ModuleName)"
-        Get-ChildItem -Path $signOutPath -Recurse 
+        Get-ChildItem -Path $signOutPath -Recurse
       displayName: Capture third party signed files output
       condition: succeededOrFailed()
 
@@ -199,7 +199,7 @@ stages:
         $config = Get-BuildConfiguration
 
         $signOutPath = "$($config.SignedOutputPath)\$($config.ModuleName)"
-        Get-ChildItem -Path $signOutPath -Recurse 
+        Get-ChildItem -Path $signOutPath -Recurse
       displayName: Capture other third party files copied
       condition: succeededOrFailed()
 
@@ -225,7 +225,7 @@ stages:
           $null = New-Item -Path $netStandardPath -ItemType Directory -Verbose
         }
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "netstandard2.0\PowerShellGet.dll") -Dest $netStandardPath -Force -Verbose
-        
+
         $signOutPath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'CreatedFilesOut'
         if (! (Test-Path -Path $signOutPath)) {
           $null = New-Item -Path $signOutPath -ItemType Directory
@@ -245,7 +245,7 @@ stages:
 
     - pwsh: |
         $createdSignSrcPath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'CreatedFiles'
-        Get-ChildItem -Path $createdSignSrcPath -Recurse 
+        Get-ChildItem -Path $createdSignSrcPath -Recurse
       displayName: Capture created files to sign source
       condition: succeededOrFailed()
 
@@ -287,7 +287,7 @@ stages:
         $config = Get-BuildConfiguration
 
         $signOutPath = "$($config.SignedOutputPath)\$($config.ModuleName)"
-        Get-ChildItem -Path $signOutPath -Recurse 
+        Get-ChildItem -Path $signOutPath -Recurse
       displayName: Capture all signed files output
       condition: succeededOrFailed()
 
@@ -321,7 +321,7 @@ stages:
         $env:PSModulePath = $modulePath + [System.IO.Path]::PathSeparator + $env:PSModulePath
         Write-Verbose -Verbose "Importing build utilities (buildtools.psd1)"
         Import-Module -Name $(Build.SourcesDirectory)/buildtools.psd1 -Force
-        
+
         $config = Get-BuildConfiguration
         $artifactName = "$($config.ModuleName)"
         if ($env:SkipSigning -eq 'True')
@@ -392,7 +392,7 @@ stages:
       jobName: TestPkgWin
       displayName: PowerShell Core on Windows
       imageName: windows-latest
-  
+
   - template: test.yml
     parameters:
       jobName: TestPkgWinPS

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ This version of PowerShellGet is currently under development and is not feature 
 As a result, we are currently only accepting PRs for tests.
 If you would like to open a PR please open an issue first so that necessary discussion can take place.
 Please open an issue for any feature requests, bug reports, or questions for PowerShellGet version 3.0 (currently available as a preview release).
-Please note, the repository for previous versions of PowerShellGet has a new location at [PowerShell/PowerShellGetv2](https://github.com/PowerShell/PowerShellGetv2).  
+Please note, the repository for previous versions of PowerShellGet has a new location at [PowerShell/PowerShellGetv2](https://github.com/PowerShell/PowerShellGetv2).
 
 Introduction
 ============
 
-PowerShellGet is a PowerShell module with commands for discovering, installing, updating and publishing the PowerShell artifacts like Modules, Scripts, and DSC Resources.  
+PowerShellGet is a PowerShell module with commands for discovering, installing, updating and publishing the PowerShell artifacts like Modules, Scripts, and DSC Resources.
 
 Documentation
 =============
 
 Documentation for PowerShellGet 3.0 has not yet been published, please
 [Click here](https://docs.microsoft.com/powershell/module/PowerShellGet/?view=powershell-7)
-to reference the documentation for previous versions of PowerShellGet.  
+to reference the documentation for previous versions of PowerShellGet.
 
 Requirements
 ============
@@ -66,6 +66,9 @@ if ((Get-Module -Name PSPackageProject -ListAvailable).Count -eq 0) {
 ```powershell
 # Build for the netstandard2.0 framework
 PS C:\Repos\PowerShellGet> .\build.ps1 -Clean -Build -BuildConfiguration Debug -BuildFramework netstandard2.0
+
+# Build for the netstandard2.0 framework
+PS C:\Repos\PowerShellGet> .\build.ps1 -Clean -Build -BuildConfiguration Debug -BuildFramework net472
 ```
 
 * Publish the module to a local repository
@@ -90,7 +93,7 @@ C:\> Import-Module C:\Repos\PowerShellGet\out\PowerShellGet
 C:\> Import-Module C:\Repos\PowerShellGet\out\PowerShellGet\PowerShellGet.psd1
 ```
 
-**Note**  
+**Note**
 PowerShellGet consists of .NET binaries and so can be imported into a PowerShell session only once.
 Since the PSPackageProject module, used to build the module, has a dependency on earlier versions of PowerShellGet, the newly built module cannot be imported into that session.
 The new module can only be imported into a new session that has no prior imported PowerShellGet module. You will recieve warning messages in the console if you encounter this issue.

--- a/build.ps1
+++ b/build.ps1
@@ -23,8 +23,8 @@ param (
     [ValidateSet("Debug", "Release")]
     [string] $BuildConfiguration = "Debug",
 
-    [ValidateSet("netstandard2.0")]
-    [string] $BuildFramework = "netstandard2.0"
+    [ValidateSet("netstandard2.0", "net472")]
+    [string] $BuildFramework = "net472"
 )
 
 Write-Verbose -Verbose -Message "(Pre) PSGet versions available:"

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -92,6 +92,14 @@ function DoBuild
                 'NuGet.Versioning'
                 'Newtonsoft.Json'
                 'System.Text.Json'
+                'System.Buffers'
+                'System.Memory'
+                'System.Numerics.Vectors'
+                'System.Runtime.CompilerServices.Unsafe'
+                'System.Text.Encodings.Web'
+                'System.Threading.Tasks.Extensions'
+                'Microsoft.Bcl.AsyncInterfaces'
+                'System.ValueTuple'
             )
 
             $buildSuccess = $true

--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 @{
-    RootModule        = './netstandard2.0/PowerShellGet.dll'
+    RootModule        = './net472/PowerShellGet.dll'
     ModuleVersion     = '3.0.19'
     GUID              = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
     Author            = 'Microsoft Corporation'

--- a/src/code/ModuleInitAndCleanup.cs
+++ b/src/code/ModuleInitAndCleanup.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Management.Automation;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
+{
+#if NET472
+    public class UnsafeAssemblyHandler : IModuleAssemblyInitializer, IModuleAssemblyCleanup
+    {
+        private static readonly string s_asmLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+        public void OnImport()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += HandleAssemblyResolve;
+        }
+
+        public void OnRemove(PSModuleInfo psModuleInfo)
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= HandleAssemblyResolve;
+        }
+
+        private static Assembly HandleAssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            var requiredAssembly = new AssemblyName(args.Name);
+
+            string possibleAssembly = Path.Combine(s_asmLocation, $"{requiredAssembly.Name}.dll");
+
+            AssemblyName bundledAssembly = null;
+
+            try
+            {
+                bundledAssembly = AssemblyName.GetAssemblyName(possibleAssembly);
+            }
+            catch
+            {
+                return null;
+            }
+
+            if (bundledAssembly.Version < requiredAssembly.Version)
+            {
+                return null;
+            }
+
+            return Assembly.LoadFrom(possibleAssembly);
+        }
+    }
+#endif
+}

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -8,7 +8,7 @@
     <AssemblyVersion>3.0.19.0</AssemblyVersion>
     <FileVersion>3.0.19</FileVersion>
     <InformationalVersion>3.0.19</InformationalVersion>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
@@ -26,6 +26,7 @@
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Load the dependencies dynamically on NET 472 to help .NET resolve them correctly

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
